### PR TITLE
allow React >=0.13.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "0.12.x"
+    "react": "0.12.x || >=0.13.0-beta.1"
   },
   "devDependencies": {
     "6to5": "^3.5.3",


### PR DESCRIPTION
Just like in [react-hot-loader](https://github.com/gaearon/react-hot-loader/blob/master/package.json#L11) to be able to use [`0.13` features](https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html) on project right now w/o peerDependencies hell. Looks like everything is working fine, API is backwards compatible.