### PR TITLE
Support for native url drag and drop

### DIFF
--- a/modules/backends/HTML5.js
+++ b/modules/backends/HTML5.js
@@ -5,6 +5,7 @@ var DragDropActionCreators = require('../actions/DragDropActionCreators'),
     NativeDragItemTypes = require('../constants/NativeDragItemTypes'),
     EnterLeaveMonitor = require('../utils/EnterLeaveMonitor'),
     isFileDragDropEvent = require('../utils/isFileDragDropEvent'),
+    isUrlDragDropEvent = require('../utils/isUrlDragDropEvent'),
     configureDataTransfer = require('../utils/configureDataTransfer'),
     shallowEqual = require('react/lib/shallowEqual'),
     isWebkit = require('../utils/isWebkit');
@@ -41,8 +42,12 @@ function triggerDragEndIfDragSourceWasRemovedFromDOM() {
   _currentComponent.handleDragEnd(type, null);
 }
 
-function preventDefaultFileDropAction(e) {
-  if (isFileDragDropEvent(e)) {
+function isNativeDragDropEvent(e) {
+  return isFileDragDropEvent(e) || isUrlDragDropEvent(e);
+}
+
+function preventDefaultNativeDropAction(e) {
+  if (isNativeDragDropEvent(e)) {
     e.preventDefault();
   }
 }
@@ -52,13 +57,17 @@ function handleTopDragEnter(e) {
   e.preventDefault();
 
   var isFirstEnter = _monitor.enter(e.target);
-  if (isFirstEnter && isFileDragDropEvent(e)) {
-    DragDropActionCreators.startDragging(NativeDragItemTypes.FILE, null);
+  if (isFirstEnter) {
+    if(isFileDragDropEvent(e)){
+      DragDropActionCreators.startDragging(NativeDragItemTypes.FILE, null);
+    } else if (isUrlDragDropEvent(e)){
+      DragDropActionCreators.startDragging(NativeDragItemTypes.URL, null);
+    }
   }
 }
 
 function handleTopDragOver(e) {
-  preventDefaultFileDropAction(e);
+  preventDefaultNativeDropAction(e);
 
   var offsetFromClient = HTML5.getOffsetFromClient(_currentComponent, e);
   DragDropActionCreators.drag(offsetFromClient);
@@ -76,20 +85,20 @@ function handleTopDragOver(e) {
 }
 
 function handleTopDragLeave(e) {
-  preventDefaultFileDropAction(e);
+  preventDefaultNativeDropAction(e);
 
   var isLastLeave = _monitor.leave(e.target);
-  if (isLastLeave && isFileDragDropEvent(e)) {
+  if (isLastLeave && isNativeDragDropEvent(e)) {
     DragDropActionCreators.endDragging();
   }
 }
 
 function handleTopDrop(e) {
-  preventDefaultFileDropAction(e);
+  preventDefaultNativeDropAction(e);
 
   _monitor.reset();
 
-  if (isFileDragDropEvent(e)) {
+  if (isNativeDragDropEvent(e)) {
     DragDropActionCreators.endDragging();
   }
 

--- a/modules/constants/NativeDragItemTypes.js
+++ b/modules/constants/NativeDragItemTypes.js
@@ -3,7 +3,8 @@
 var keyMirror = require('react/lib/keyMirror');
 
 var NativeDragItemTypes = {
-  FILE: '__NATIVE_FILE__'
+  FILE: '__NATIVE_FILE__',
+  URL: '__NATIVE_URL__'
 };
 
 module.exports = NativeDragItemTypes;

--- a/modules/utils/createDragDropMixin.js
+++ b/modules/utils/createDragDropMixin.js
@@ -9,6 +9,7 @@ var DragDropActionCreators = require('../actions/DragDropActionCreators'),
     DefaultDropTarget = require('./DefaultDropTarget'),
     LegacyDefaultDropTarget = require('./LegacyDefaultDropTarget'),
     isFileDragDropEvent = require('./isFileDragDropEvent'),
+    isUrlDragDropEvent = require('../utils/isUrlDragDropEvent'),
     invariant = require('react/lib/invariant'),
     warning = require('react/lib/warning'),
     assign = require('react/lib/Object.assign'),
@@ -308,8 +309,8 @@ function createDragDropMixin(backend) {
       var { enter, getDropEffect } = this._dropTargets[this.state.draggedItemType],
           effectsAllowed = DragOperationStore.getEffectsAllowed();
 
-      if (isFileDragDropEvent(e)) {
-        // Use Copy drop effect for dragging files.
+      if (isFileDragDropEvent(e) || isUrlDragDropEvent(e)) {
+        // Use Copy drop effect for dragging files or urls.
         // Because browser gives no drag preview, "+" icon is useful.
         effectsAllowed = [DropEffects.COPY];
       }
@@ -380,8 +381,14 @@ function createDragDropMixin(backend) {
         item = {
           files: Array.prototype.slice.call(e.dataTransfer.files)
         };
+      } else if (isUrlDragDropEvent(e)) {
+        // getData('Url')  --> IE support
+        var urlsStr = e.dataTransfer.getData('Url') || e.dataTransfer.getData('text/uri-list') || ''
+        var urls = urlsStr.split('\n');
+        item = {
+          urls: urls
+        };
       }
-
       this._monitor.reset();
 
       if (!isHandled) {

--- a/modules/utils/isUrlDragDropEvent.js
+++ b/modules/utils/isUrlDragDropEvent.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function isUrlDragDropEvent(e) {
+  var types = Array.prototype.slice.call(e.dataTransfer.types);
+  return types.indexOf('Url') !== -1 || types.indexOf('text/uri-list') !== -1;
+}
+
+module.exports = isUrlDragDropEvent;


### PR DESCRIPTION
hi @gaearon ,

That would be great to add support for native links to this library. This will allow user to drag links from other browser windows for example.

Enhanced from PR https://github.com/gaearon/react-dnd/pull/94
* fix formatting
* added IE support and make it more robust to null returns by dataTransfer.getData
* excluded `dist/` ,`dist-modules/`, `.gitignore` commits

Hoping we could merge this to master soon.

thanks! 

-seb
