### PR TITLE
Capture dropzones for correct enter/leave state

### DIFF
--- a/modules/actions/DragDropActionCreators.js
+++ b/modules/actions/DragDropActionCreators.js
@@ -33,6 +33,20 @@ var DragDropActionCreators = {
     DragDropDispatcher.handleAction({
       type: DragDropActionTypes.DRAG_END
     });
+  },
+
+  captureDropTarget(component) {
+    DragDropDispatcher.handleAction({
+      type: DragDropActionTypes.CAPTURE_DROP_TARGET,
+      component: component
+    });
+  },
+
+  releaseDropTarget(component) {
+    DragDropDispatcher.handleAction({
+      type: DragDropActionTypes.RELEASE_DROP_TARGET,
+       component: component
+    });
   }
 };
 

--- a/modules/constants/DragDropActionTypes.js
+++ b/modules/constants/DragDropActionTypes.js
@@ -6,7 +6,9 @@ var DragDropActionTypes = keyMirror({
   DRAG_START: null,
   DRAG_END: null,
   DRAG: null,
-  DROP: null
+  DROP: null,
+  CAPTURE_DROP_TARGET: null,
+  RELEASE_DROP_TARGET: null
 });
 
 module.exports = DragDropActionTypes;

--- a/modules/stores/DragOperationStore.js
+++ b/modules/stores/DragOperationStore.js
@@ -8,7 +8,8 @@ var DragDropDispatcher = require('../dispatcher/DragDropDispatcher'),
 var _draggedItem = null,
     _draggedItemType = null,
     _effectsAllowed = null,
-    _dropEffect = null;
+    _dropEffect = null,
+    _dropTargets = [];
 
 var DragOperationStore = createStore({
   isDragging() {
@@ -29,6 +30,10 @@ var DragOperationStore = createStore({
 
   getDraggedItemType() {
     return _draggedItemType;
+  },
+
+  getActiveDropTarget() {
+    return _dropTargets[_dropTargets.length - 1] || null;
   }
 });
 
@@ -48,6 +53,7 @@ DragOperationStore.dispatchToken = DragDropDispatcher.register(function (payload
 
   case DragDropActionTypes.DROP:
     _dropEffect = action.dropEffect;
+    _dropTargets = [];
     DragOperationStore.emitChange();
     break;
 
@@ -56,6 +62,24 @@ DragOperationStore.dispatchToken = DragDropDispatcher.register(function (payload
     _draggedItemType = null;
     _effectsAllowed = null;
     _dropEffect = null;
+    DragOperationStore.emitChange();
+    break;
+
+  case DragDropActionTypes.CAPTURE_DROP_TARGET:
+    if (_dropTargets.indexOf(action.component) === -1) {
+      _dropTargets.push(action.component);
+    }
+
+    DragOperationStore.emitChange();
+    break;
+
+  case DragDropActionTypes.RELEASE_DROP_TARGET:
+    var index = _dropTargets.indexOf(action.component);
+
+    if (index > -1) {
+      _dropTargets.splice(index, 1);
+    }
+
     DragOperationStore.emitChange();
     break;
   }

--- a/modules/utils/createDragDropMixin.js
+++ b/modules/utils/createDragDropMixin.js
@@ -137,7 +137,7 @@ function createDragDropMixin(backend) {
       return {
         isDragging: isDragging,
         isOver: isDragging && isOver,
-        isOverCurrent: false // TODO
+        isOverCurrent: DragOperationStore.getActiveDropTarget() === this
       };
     },
 
@@ -326,6 +326,8 @@ function createDragDropMixin(backend) {
         currentDropEffect: dropEffect
       });
 
+      DragDropActionCreators.captureDropTarget(this);
+
       callDragDropLifecycle(enter, this, this.state.draggedItem, e);
     },
 
@@ -355,6 +357,8 @@ function createDragDropMixin(backend) {
       this.setState({
         currentDropEffect: null
       });
+
+      DragDropActionCreators.releaseDropTarget(this);
 
       var { leave } = this._dropTargets[this.state.draggedItemType];
       callDragDropLifecycle(leave, this, this.state.draggedItem, e);


### PR DESCRIPTION
This is one attempt at implementing `isOverCurrent` by @itrelease extracted from #85.

This still doesn't solve `enter` / `over` / `leave`. We want to be able to execute side effects on `enterCurrent`, `overCurrent` and `leaveCurrent`. (By the way I'm open to better name suggestions.)

If there are better API ideas, again, I'm all ears.