### PR TITLE
nulls offsets on drag end and exposes initial container offset to context

### DIFF
--- a/modules/stores/DragOffsetStore.js
+++ b/modules/stores/DragOffsetStore.js
@@ -39,7 +39,8 @@ DragOffsetStore.dispatchToken = DragDropDispatcher.register(function (payload) {
     break;
 
   case DragDropActionTypes.DRAG_END:
-    _currentOffsetFromClient = null;
+    _initialOffsetFromContainer = null;
+    _initialOffsetFromClient = null;
     _currentOffsetFromClient = null;
     DragOffsetStore.emitChange();
   }

--- a/modules/utils/DragDropContext.js
+++ b/modules/utils/DragDropContext.js
@@ -19,6 +19,10 @@ var DragDropContext = {
 
   getCurrentOffsetFromClient() {
     return DragOffsetStore.getCurrentOffsetFromClient();
+  },
+
+  getInitialOffsetFromContainer() {
+    return DragOffsetStore.getInitialOffsetFromContainer();
   }
 };
 


### PR DESCRIPTION
I am using the initial offset from container to calculate offset when dragging between containers.