### PR TITLE
Support for React 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "0.12.x || >=0.13.0-beta.1"
+    "react": "0.12.x || >=0.13.0"
   },
   "devDependencies": {
     "6to5": "^3.5.3",


### PR DESCRIPTION
The current peerDependencies make it impossible to use with the new React 0.13.0 (released 15 hours ago)