### PR TITLE
DragLayerMixin: exposes all raw objects

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -135,7 +135,10 @@ Returns all you need in order to draw a custom drag layer:
   draggedItemType: string,
   draggedItem: Object,
   initialOffset: { x, y },
-  currentOffset: { x, y }
+  currentOffset: { x, y },
+  currentOffsetFromClient: { x, y },
+  initialOffsetFromClient: { x, y },
+  initialOffsetFromContainer: { x, y }
 }
 ```
 

--- a/modules/mixins/DragLayerMixin.js
+++ b/modules/mixins/DragLayerMixin.js
@@ -9,8 +9,8 @@ var DragLayerMixin = {
   },
 
   getDragLayerState() {
-    var { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset } = this.state;
-    return { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset };
+    var { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset, currentOffsetFromClient, initialOffsetFromClient, initialOffsetFromContainer } = this.state;
+    return { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset, currentOffsetFromClient, initialOffsetFromClient, initialOffsetFromContainer };
   },
 
   getStateForDragLayerMixin() {
@@ -39,7 +39,7 @@ var DragLayerMixin = {
       };
     }
 
-    return { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset };
+    return { isDragging, draggedItemType, draggedItem, initialOffset, currentOffset, currentOffsetFromClient, initialOffsetFromClient, initialOffsetFromContainer };
   },
 
   handleStoreChangeInDragLayerMixin() {


### PR DESCRIPTION
as suggested in #117,

getDragLayerState() now also exposes: `currentOffsetFromClient`, `initialOffsetFromClient`, `initialOffsetFromContainer`