### PR TITLE
Wrap checkboxes and text with <label>

### DIFF
--- a/examples/_drag-around-custom/index.js
+++ b/examples/_drag-around-custom/index.js
@@ -23,15 +23,19 @@ const DragAroundCustom = React.createClass({
         <Container snapToGrid={snapToGridAfterDrop} />
         <DragLayer snapToGrid={snapToGridWhileDragging} />
         <p>
-          <input type='checkbox'
-                 checkedLink={this.linkState('snapToGridAfterDrop')}>
-            Snap to grid after drop
-          </input>
+          <label>
+            <input type='checkbox'
+                   checkedLink={this.linkState('snapToGridAfterDrop')}>
+              Snap to grid after drop
+            </input>
+          </label>
           <br />
-          <input type='checkbox'
-                 checkedLink={this.linkState('snapToGridWhileDragging')}>
-            Snap to grid while dragging
-          </input>
+          <label>
+            <input type='checkbox'
+                   checkedLink={this.linkState('snapToGridWhileDragging')}>
+              Snap to grid while dragging
+            </input>
+          </label>
         </p>
         <hr />
         <p>

--- a/examples/_drag-around-naive/index.js
+++ b/examples/_drag-around-naive/index.js
@@ -21,10 +21,12 @@ const DragAroundNaive = React.createClass({
       <div>
         <Container hideSourceOnDrag={hideSourceOnDrag} />
         <p>
-          <input type='checkbox'
-                 checkedLink={this.linkState('hideSourceOnDrag')}>
-            Hide source item while dragging
-          </input>
+          <label>
+            <input type='checkbox'
+                   checkedLink={this.linkState('hideSourceOnDrag')}>
+              Hide source item while dragging
+            </input>
+          </label>
         </p>
         <hr />
         <p>


### PR DESCRIPTION
Examples (“drag-around-naive” and “drag-around-custom”)

Before: only checkbox itself is clickable
Now: checkbox and it’s label are clickable