### PR TITLE
Document `getInitialOffsetFromContainer()` in API doc

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -119,6 +119,10 @@ Returns `{ x, y }` coordinates of the last recorded mouse position in client coo
 
 Returns relative `{ x, y }` coordinate delta between last recorded mouse position and its position when dragging started.
 
+##### `getInitialOffsetFromContainer()`
+
+Returns `{x, y}` coordinates of mouse position relative to the top-left corner of the drag source element.
+
 ## `DragLayerMixin`
 
 Allows you to draw a custom drag layer. This can be used in combination with returning a transparent one-pixel image as `dragPreview` from `beginDrag` so that only your custom layer is visible.


### PR DESCRIPTION
Add `DragDropContext.getInitialOffsetFromContainer()` to the API documentation.

Currently it is a "hidden" method that needs documentation.

I just had a use for it today and stumbled upon it while logging the `DragDropContext`