### PR TITLE
Add minified builds back to NPM/Bower

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 src
-dist
 scripts
 examples
 site

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,6 @@
     "**/.*",
     "node_modules",
     "src/",
-    "dist/",
     "scripts/",
     "examples/",
     "site/",


### PR DESCRIPTION
In its current state, the Bower package is a docs folder and some config files. Adding the minified version back covers corner cases (e.g. AMD).

Discussion found in https://github.com/gaearon/react-dnd/issues/189#issuecomment-111467063