### PR TITLE
Fixes to Drag Layer API documentation.

### DIFF
--- a/docs/01 Top Level API/DragLayer.md
+++ b/docs/01 Top Level API/DragLayer.md
@@ -238,7 +238,7 @@ function collect(monitor) {
   };
 }
 
-export default DragLayer(collect)(CustomDragSource);
+export default DragLayer(collect)(CustomDragLayer);
 ```
 -------------------
 ```js


### PR DESCRIPTION
Replace supposed typo `CustomDragSource` with `CustomDragLayer` for ES 6 documentation.