### PR TITLE
Missing parameter in docs example

### DIFF
--- a/docs/01 Top Level API/DragSource.md
+++ b/docs/01 Top Level API/DragSource.md
@@ -147,7 +147,7 @@ var cardSource = {
     return item;
   },
 
-  isDragging: function (props) {
+  isDragging: function (props, monitor) {
     // If your component gets unmounted while dragged
     // (like a card in Kanban board dragged between lists)
     // you can implement something like this to keep its


### PR DESCRIPTION
the example is missing the monitor as a second parameter.