### PR TITLE
fix anchor link open in FF

### DIFF
--- a/src/backends/HTML5.js
+++ b/src/backends/HTML5.js
@@ -542,6 +542,9 @@ class HTML5Backend {
   }
 
   handleDrop(e, targetId) {
+    // prevent default action. This happens when the child of
+    // the draggable element is an anchor link.
+    isFirefox() && e.preventDefault();
     this.dropTargetIds.unshift(targetId);
   }
 


### PR DESCRIPTION
If I don't `preventDefault` on `drop` in FF and the draggable item has an anchor link, the anchor link will be opened.

Reference: https://developer.mozilla.org/en-US/docs/Web/Events/drop