### PR TITLE
Typo fix.

### DIFF
--- a/docs/00 Quick Start/Overview.md
+++ b/docs/00 Quick Start/Overview.md
@@ -51,7 +51,7 @@ It instructs React DnD to pass the up-to-date values of `highlighted` and `hover
 
 If the backend handles the DOM events, but the components use React to describe the DOM, how does the backend know which DOM nodes to listen to? Enter the *connectors*. **The connectors let you assign one of the predefined roles (a drag source, a drag preview, or a drop target) to the DOM nodes** in your `render` function.
 
-In fact, a connector is passed as a second argument to the *collecting function* we described above. Let's see how we can use it to specify the drag source:
+In fact, a connector is passed as a second argument to the *collecting function* we described above. Let's see how we can use it to specify the drop target:
 
 ```js
 function collect(connect, monitor) {


### PR DESCRIPTION
Example is showing how to make a ``Cell`` a ``DropTarget``, but description talks about "drag source".

Maybe the change has to be the other way around? maybe we need to change the example code? Although the change will be bigger, we'd need to change ``isOver`` and ``canDrop`` for some ``DragSourceMonitor`` methods. Let me know.

