### PR TITLE
A generic sortable example and components for Issue 305

### DIFF
--- a/examples/04 Sortable/Generic/Sortable.js
+++ b/examples/04 Sortable/Generic/Sortable.js
@@ -1,0 +1,208 @@
+import React, {Component, PropTypes} from 'react';
+import {DropTarget} from 'react-dnd';
+import SortableItem from './SortableItem';
+
+const _getLastChildKeyFromComponent = (component) => {
+  const allItems = component.state.children;
+  let lastChild = null;
+  React.Children.forEach(allItems, (child, i) => {
+    if (i === React.Children.count(allItems) - 1) lastChild = child;
+  });
+  return lastChild.props.eventKey;
+};
+
+const sortableTarget = {
+  canDrop(props, monitor) {
+    let isSibling = false;
+
+    // Only allow re-ordering siblings
+    React.Children.forEach(props.children.props.children, (child) => {
+      if (isSibling) return;
+      isSibling = child === monitor.getItem().children;
+    });
+
+    return isSibling;
+  },
+
+  hover(props, monitor, component) {
+    // If we're dragging on top of an existing SortableItem - do nothing
+    if (!component.props.isOverCurrent) return;
+
+    // Not allowed to drop here
+    if (!monitor.canDrop()) return;
+
+    const item = monitor.getItem();
+    const draggedKey = item.children.props.eventKey;
+    const lastKey = _getLastChildKeyFromComponent(component);
+
+    if (draggedKey !== lastKey) {
+      item.onMove(draggedKey, lastKey);
+    } else {
+      item.onMoveReset();
+    }
+  },
+
+  drop(props, monitor, component) {
+    // Already dropped on a nested SortedItem - do nothing
+    if (monitor.didDrop()) return;
+
+    const item = monitor.getItem();
+
+    // Dropped on the empty space in the Sortable component - put on the bottom
+    const fromKey = item.children.props.eventKey;
+    const lastKey = _getLastChildKeyFromComponent(component);
+    item.onDrop(fromKey, lastKey);
+
+    // Fire the onSort callback
+    item.onSort(item, monitor);
+  }
+};
+
+@DropTarget('SortableItem', sortableTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver(),
+  isOverCurrent: monitor.isOver({shallow: true})
+}))
+export default class Sortable extends Component {
+  static displayName: "Sortable";
+
+  static propTypes = {
+    children: PropTypes.any,
+    connectDropTarget: PropTypes.func.isRequired,
+    dragAxis: PropTypes.oneOf(['x', 'y']).isRequired,
+    enabled: PropTypes.bool,
+    isOver: PropTypes.bool.isRequired,
+    isOverCurrent: PropTypes.bool.isRequired,
+    onSort: PropTypes.func
+  }
+
+  static defaultProps = {
+    dragAxis: 'x',
+    enabled: true,
+    onSort: () => {}
+  }
+
+  constructor(props) {
+    super(props);
+
+    const parent = this.props.children ? React.Children.only(this.props.children) : null;
+
+    this.state = {
+      // A reference to the children props which will be used in the sorting calculation
+      children: parent ? parent.props.children : [],
+
+      // During draggin, at what index should the drop placeholder appear
+      placeholderIndex: null
+    };
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    // If the children have changed, we need to update the local cache
+    if (nextProps.children.props.children !== this.props.children.props.children) {
+      nextState.children = nextProps.children.props.children;
+    }
+  }
+
+  render() {
+    // Safely handle empty elements
+    if (!this.props.children) return <span/>;
+
+    const {connectDropTarget, isOver} = this.props;
+    const parent = React.Children.only(this.props.children);
+    const classes = [
+      'ui-sortable',
+      parent.props.className
+    ];
+
+    const childCount = React.Children.count(this.state.children);
+
+    return connectDropTarget(React.cloneElement(parent, {
+      className: classes.join(' '),
+      children: React.Children.map(this.state.children, (child, i) => {
+        if (!child) return null;
+
+        const result = [];
+        if (isOver && i === this.state.placeholderIndex) {
+          result.push(this._renderPlaceholder());
+        }
+
+        result.push(
+          <SortableItem
+            enabled={this.props.enabled}
+            getSortOrder={this.getSortOrder}
+            key={child.props.eventKey}
+            onDrop={this._handleDrop}
+            onMove={this._handleMove}
+            onMoveReset={this._handleMoveReset}
+            onSort={this.props.onSort}
+            parentChildren={this.props.children.props.children}>
+            {child}
+          </SortableItem>
+        );
+
+        if (isOver && childCount === this.state.placeholderIndex && i === childCount - 1) {
+          result.push(this._renderPlaceholder());
+        }
+
+        return result;
+      })
+    }));
+  }
+
+  _renderPlaceholder() {
+    return (
+      <div className={`ui-sortable-placeholder ui-sortable-placeholder-${this.props.dragAxis}`} style={{borderTop: '1px solid gray'}}/>
+    );
+  }
+
+  getSortOrder = () => {
+    const keys = [];
+    React.Children.forEach(this.state.children, (c) => keys.push(c.props.eventKey));
+    return keys;
+  }
+
+  _handleDrop = (fromKey, toKey) => {
+    const {children} = this.state;
+
+    let fromIndex = -1;
+    let toIndex = -1;
+
+    const childrenArray = [];
+
+    React.Children.forEach(children, (c, i) => {
+      if (c.props.eventKey === fromKey) fromIndex = i;
+      if (c.props.eventKey === toKey) toIndex = i;
+      childrenArray.push(c);
+    });
+
+    childrenArray.splice(toIndex, 0, childrenArray.splice(fromIndex, 1)[0]);
+
+    this.setState({
+      children: childrenArray
+    });
+  }
+
+  _handleMove = (fromKey, toKey) => {
+    const {children} = this.state;
+
+    let fromIndex = null;
+    let toIndex = null;
+
+    React.Children.forEach(children, (c, i) => {
+      if (c.props.eventKey === toKey) toIndex = i;
+      if (c.props.eventKey === fromKey) fromIndex = i;
+    });
+
+    if (toIndex > fromIndex) toIndex++;
+
+    this.setState({
+      placeholderIndex: toIndex
+    });
+  }
+
+  _handleMoveReset = () => {
+    this.setState({
+      placeholderIndex: null
+    });
+  }
+}

--- a/examples/04 Sortable/Generic/SortableItem.js
+++ b/examples/04 Sortable/Generic/SortableItem.js
@@ -1,0 +1,108 @@
+import React, {Component, PropTypes} from 'react';
+import {findDOMNode} from 'react-dom';
+import {DragSource, DropTarget} from 'react-dnd';
+
+const sortableSource = {
+  beginDrag(props) {
+    return props;
+  },
+
+  canDrag(props) {
+    return props.enabled;
+  },
+
+  endDrag(props) {
+    props.onMoveReset();
+  }
+};
+
+const sortableTarget = {
+  canDrop(props, monitor) {
+    let isSibling = false;
+
+    React.Children.forEach(props.parentChildren, (child) => {
+      if (isSibling) return;
+      isSibling = child === monitor.getItem().children;
+    });
+
+    return isSibling;
+  },
+
+  hover(props, monitor) {
+    if (!monitor.canDrop()) return;
+
+    const draggedKey = monitor.getItem().children.props.eventKey;
+
+    if (draggedKey !== props.children.props.eventKey) {
+      props.onMove(draggedKey, props.children.props.eventKey);
+    } else {
+      props.onMoveReset();
+    }
+  },
+
+  drop(props, monitor) {
+    const fromKey = monitor.getItem().children.props.eventKey;
+    const toKey = props.children.props.eventKey;
+    props.onDrop(fromKey, toKey);
+
+    props.onSort(props, monitor);
+  }
+};
+
+@DropTarget('SortableItem', sortableTarget, (connect) => ({
+  connectDropTarget: connect.dropTarget()
+}))
+@DragSource('SortableItem', sortableSource, (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  isDragging: monitor.isDragging()
+}))
+export default class SortableItem extends Component {
+  static displayName = 'SortableItem';
+
+  static propTypes = {
+    children: PropTypes.any,
+    connectDragSource: PropTypes.func.isRequired,
+    connectDropTarget: PropTypes.func.isRequired,
+    isDragging: PropTypes.bool.isRequired,
+    onMove: PropTypes.func.isRequired,
+    onMoveReset: PropTypes.func.isRequired,
+    onSort: PropTypes.func.isRequired,
+    parentChildren: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.object
+    ])
+  }
+
+  static defaultProps = {
+    onSort: () => {}
+  }
+
+  render() {
+    if (!this.props.children) return <span/>;
+
+    const {isDragging, connectDragSource, connectDropTarget} = this.props;
+    const child = React.Children.only(this.props.children);
+
+    const classes = [
+      'ui-sortable-item',
+      isDragging ? 'ui-dragging' : null,
+      child.props.className
+    ];
+
+    return connectDragSource(
+      connectDropTarget(
+        React.cloneElement(child, {
+          className: classes.join(' ')
+        })
+      )
+    );
+
+    // We tried doing this to fix the issue -- but it doesn't work:
+    /*
+    return React.cloneElement(child, {
+      className: classes.join(' '),
+      ref: ref: (instance) => connectDragSource(connectDropTarget(findDOMNode(instance)))
+    });
+    */
+  }
+}

--- a/examples/04 Sortable/Generic/SortableItem.js
+++ b/examples/04 Sortable/Generic/SortableItem.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {findDOMNode} from 'react-dom';
+//import {findDOMNode} from 'react-dom';
 import {DragSource, DropTarget} from 'react-dnd';
 
 const sortableSource = {

--- a/examples/04 Sortable/Generic/index.js
+++ b/examples/04 Sortable/Generic/index.js
@@ -1,0 +1,54 @@
+import React, { Component, PropTypes } from 'react';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import Sortable from './Sortable';
+
+class CustomElement extends Component {
+  static propTypes = {
+    children: PropTypes.any
+  }
+
+  // Do not modify this component. This is just an example to reproduce the problem.
+  // In practice the CustomElement component is something we cannot control.
+  render() {
+    return <div>{this.props.children}</div>;
+  }
+}
+
+@DragDropContext(HTML5Backend)
+export default class SortableGeneric extends Component {
+  render() {
+    return (
+      <div>
+        <p>
+          <b><a href='https://github.com/gaearon/react-dnd/tree/master/examples/04%20Sortable/Generic'>Browse the Source</a></b>
+        </p>
+        <p>
+          This is a test use case submission for issue reported at <a href="https://github.com/gaearon/react-dnd/issues/305#issuecomment-152247354">https://github.com/gaearon/react-dnd/issues/305#issuecomment-152247354</a>.
+        </p>
+        <p>
+          The component below works because the elements are divs.
+        </p>
+        <Sortable>
+            <div>
+                <div eventKey="1">Item 1</div>
+                <div eventKey="2">Item 2</div>
+                <div eventKey="3">Item 3</div>
+                <div eventKey="4">Item 4</div>
+            </div>
+        </Sortable>
+        <p>
+          However, this no longer works. And it is not clear how we should fix the SortableItem component to deal with it.
+        </p>
+        <Sortable>
+            <div>
+                <CustomElement eventKey="1">Item 1</CustomElement>
+                <CustomElement eventKey="2">Item 2</CustomElement>
+                <CustomElement eventKey="3">Item 3</CustomElement>
+                <CustomElement eventKey="4">Item 4</CustomElement>
+            </div>
+        </Sortable>
+      </div>
+    );
+  }
+}

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -146,6 +146,10 @@ export const ExamplePages = [{
       location: 'examples-sortable-simple.html',
       title: 'Simple'
     },
+    SORTABLE_GENERIC: {
+      location: 'examples-sortable-generic.html',
+      title: 'Generic'
+    },
     SORTABLE_CANCEL_ON_DROP_OUTSIDE: {
       location: 'examples-sortable-cancel-on-drop-outside.html',
       title: 'Cancel on Drop Outside'

--- a/site/IndexPage.js
+++ b/site/IndexPage.js
@@ -34,6 +34,7 @@ const Examples = {
   NESTING_DRAG_SOURCES: require('../examples/03 Nesting/Drag Sources'),
   NESTING_DROP_TARGETS: require('../examples/03 Nesting/Drop Targets'),
   SORTABLE_SIMPLE: require('../examples/04 Sortable/Simple'),
+  SORTABLE_GENERIC: require('../examples/04 Sortable/Generic'),
   SORTABLE_CANCEL_ON_DROP_OUTSIDE: require('../examples/04 Sortable/Cancel on Drop Outside'),
   SORTABLE_STRESS_TEST: require('../examples/04 Sortable/Stress Test'),
   CUSTOMIZE_HANDLES_AND_PREVIEWS: require('../examples/05 Customize/Handles and Previews'),


### PR DESCRIPTION
Hey @gaearon,

Thanks a lot for your work on this project and for your time in helping us figure out a proper upgrade solution from 1.0 to 2.0.

This PR is an example which demonstrates our usage of react-dnd and the challenge reported here: https://github.com/gaearon/react-dnd/issues/305#issuecomment-152247354

Steps to reproduce:
- Run `npm run start`
- Navigate to the new "Generic" example page under "Sortable"
- Here we are showing a simple example of our `<Sortable/>` component whose job is to accept any element and make it sortable. The example enabled by default is using <div> elements and is working just fine. However, if you go into the code, you'll see we also try to sort `<CustomElement/>` object -- and this isn't working.

If you take a look at our `<SortableItem/>` component you'll see some comments in the render methods as to what we tried and what isn't working.

Any recommendations would be greatly appreciated.