### PR TITLE
Fix DragLayer ES5 documentation example.

### DIFF
--- a/docs/01 Top Level API/DragLayer.md
+++ b/docs/01 Top Level API/DragLayer.md
@@ -103,7 +103,7 @@ function getItemStyles(props) {
 
   var x = currentOffset.x;
   var y = currentOffset.y;
-  const transform = 'translate(' + x + 'px, ' + y + 'px)';
+  var transform = 'translate(' + x + 'px, ' + y + 'px)';
   return {
     transform: transform,
     WebkitTransform: transform


### PR DESCRIPTION
Fix small mistake where ES5 example contained `const`.