### PR TITLE
build both dev and minified versions to dist

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,8 @@
 
 # build minified standalone version in dist
 rm -rf dist
-./node_modules/.bin/webpack
+./node_modules/.bin/webpack --output-filename=dist/ReactDnD.js
+./node_modules/.bin/webpack --output-filename=dist/ReactDnD.min.js --optimize-minimize
 
 # build ES5 modules to lib
 rm -rf lib

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,11 +26,6 @@ module.exports = {
       'process.env': {
         'NODE_ENV': JSON.stringify('production')
       }
-    }),
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        warnings: false
-      }
     })
   ]
 };


### PR DESCRIPTION
I'm building a Cljsjs package (https://github.com/cljsjs/packages/wiki/Creating-Packages) for react-dnd and would like a development version that I can minify during the build process (so that consumers of the package have access to both versions).

I don't have much experience with webpack, so I'm not sure if there's a good reason to use UglifyJs instead of Webpack's `--optimize-minimize` command-line option--if there is, I can make a new pull request.