### PR TITLE
Subscribe DragLayers to state changes. Fixes #293

### DIFF
--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -68,11 +68,13 @@ export default function DragLayer(collect, options = {}) {
 
       componentDidMount() {
         const monitor = this.manager.getMonitor();
-        this.unsubscribe = monitor.subscribeToOffsetChange(this.handleChange);
+        this.unsubscribeFromOffsetChange = monitor.subscribeToOffsetChange(this.handleChange);
+        this.unsubscribeFromStateChange = monitor.subscribeToStateChange(this.handleChange);
       }
 
       componentWillUnmount() {
-        this.unsubscribe();
+        this.unsubscribeFromOffsetChange();
+        this.unsubscribeFromStateChange();
       }
 
       handleChange() {

--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -68,11 +68,13 @@ export default function DragLayer(collect, options = {}) {
 
       componentDidMount() {
         const monitor = this.manager.getMonitor();
-        this.unsubscribe = monitor.subscribeToStateChange(this.handleChange);
+        this.unsubscribeFromOffsetChange = monitor.subscribeToOffsetChange(this.handleChange);
+        this.unsubscribeFromStateChange = monitor.subscribeToStateChange(this.handleChange);
       }
 
       componentWillUnmount() {
-        this.unsubscribe;
+        this.unsubscribeFromOffsetChange();
+        this.unsubscribeFromStateChange();
       }
 
       handleChange() {

--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -72,7 +72,7 @@ export default function DragLayer(collect, options = {}) {
       }
 
       componentWillUnmount() {
-        this.unsubscribe();
+        this.unsubscribe;
       }
 
       handleChange() {

--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -72,7 +72,7 @@ export default function DragLayer(collect, options = {}) {
       }
 
       componentWillUnmount() {
-        this.unsubscribe;
+        this.unsubscribe();
       }
 
       handleChange() {

--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -68,13 +68,11 @@ export default function DragLayer(collect, options = {}) {
 
       componentDidMount() {
         const monitor = this.manager.getMonitor();
-        this.unsubscribeFromOffsetChange = monitor.subscribeToOffsetChange(this.handleChange);
-        this.unsubscribeFromStateChange = monitor.subscribeToStateChange(this.handleChange);
+        this.unsubscribe = monitor.subscribeToStateChange(this.handleChange);
       }
 
       componentWillUnmount() {
-        this.unsubscribeFromOffsetChange();
-        this.unsubscribeFromStateChange();
+        this.unsubscribe;
       }
 
       handleChange() {


### PR DESCRIPTION
Fixes the issue noted in #293 by subscribing DragLayers to state changes from Monitor in addition to offset changes.  Now, ending a drag with a drop correctly calls the DragLayer's collect function.