### PR TITLE
Expose isDragging to TargetMonitor

### DIFF
--- a/src/createTargetMonitor.js
+++ b/src/createTargetMonitor.js
@@ -26,6 +26,10 @@ class TargetMonitor {
     }
   }
 
+  isDragging() {
+    return this.internalMonitor.isDragging();
+  }
+
   isOver(options) {
     return this.internalMonitor.isOverTarget(this.targetId, options);
   }


### PR DESCRIPTION
The scenario where I need `isDragging` is described as following:

The drop targets, when no dragging, need to have certain CSS classes;
When deagging, if a specific target cannot be dropped it needs to have a
specific CSS class. And when it can it needs another CSS class.

The difficulty is that without `isDragging` the code cannot distinguish
between the first scenario (no dragging occurs) and the second (dragging
but cannot be dragged based on business rules)