### PR TITLE
Fixes #296 Cannot find valid target when multiple drop types specified

### DIFF
--- a/src/decorateHandler.js
+++ b/src/decorateHandler.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { Disposable, CompositeDisposable, SerialDisposable } from 'disposables';
 import shallowEqual from './utils/shallowEqual';
 import shallowEqualScalar from './utils/shallowEqualScalar';
+import isEqual from 'lodash/lang/isEqual';
 import isPlainObject from 'lodash/lang/isPlainObject';
 import invariant from 'invariant';
 import bindConnector from './bindConnector';
@@ -85,7 +86,8 @@ export default function decorateHandler({
     }
 
     receiveType(type) {
-      if (type === this.currentType) {
+      if (type === this.currentType || 
+          Array.isArray(type) && Array.isArray(this.currentType) && isEqual(type.slice().sort(), this.currentType.slice().sort())) {
         return;
       }
 

--- a/src/decorateHandler.js
+++ b/src/decorateHandler.js
@@ -86,8 +86,7 @@ export default function decorateHandler({
     }
 
     receiveType(type) {
-      if (type === this.currentType || 
-          Array.isArray(type) && Array.isArray(this.currentType) && isEqual(type.slice().sort(), this.currentType.slice().sort())) {
+      if (type === this.currentType || Array.isArray(type) && Array.isArray(this.currentType) && isEqual(type.slice().sort(), this.currentType.slice().sort())) {
         return;
       }
 


### PR DESCRIPTION
Fixes the issue from #296 where drop types are compared by reference only. If both drop types are arrays, an additional array comparison is performed.