### PR TITLE
fix(docs): update examples to use findDOMNode from react-dom

### DIFF
--- a/docs/01 Top Level API/DropTarget.md
+++ b/docs/01 Top Level API/DropTarget.md
@@ -124,6 +124,7 @@ Check out [the tutorial](docs-tutorial.html) for more real examples!
 -------------------
 ```js
 var React = require('react');
+var findDOMNode = require('react-dom').findDOMNode;
 var DropTarget = require('react-dnd').DropTarget;
 
 // Drag sources and drop targets only interact
@@ -239,6 +240,7 @@ module.exports = DropTarget(Types.CHESSPIECE, chessSquareTarget, collect)(ChessS
 -------------------
 ```js
 import React from 'react';
+import { findDOMNode } from 'react-dom';
 import { DropTarget } from 'react-dnd';
 
 // Drag sources and drop targets only interact
@@ -352,6 +354,7 @@ export default DropTarget(Types.CHESSPIECE, chessSquareTarget, collect)(ChessSqu
 -------------------
 ```js
 import React from 'react';
+import { findDOMNode } from 'react-dom';
 import { DropTarget } from 'react-dnd';
 
 // Drag sources and drop targets only interact

--- a/site/components/CodeBlock.js
+++ b/site/components/CodeBlock.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component, findDOMNode } from 'react';
+import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import ReactUpdates from 'react/lib/ReactUpdates';
 import StaticHTMLBlock from './StaticHTMLBlock';
 


### PR DESCRIPTION
Some people tend to be quite confused about this since the bump to React 0.14, this may help a bit!