### PR TITLE
#412 Adds support for React 15 and upgrades current website to React 15 RC2

### DIFF
--- a/examples/01 Dustbin/Single Target/__tests__/Box-test.js
+++ b/examples/01 Dustbin/Single Target/__tests__/Box-test.js
@@ -19,7 +19,7 @@ describe('Box', () => {
                    isDragging={false} />
     );
     let div = TestUtils.findRenderedDOMComponentWithTag(root, 'div');
-    expect(div.props.style.opacity).toEqual(1);
+	expect(div.style.opacity).toEqual('1');
 
     // Render with another set of props and test
     root = TestUtils.renderIntoDocument(
@@ -28,7 +28,7 @@ describe('Box', () => {
                    isDragging />
     );
     div = TestUtils.findRenderedDOMComponentWithTag(root, 'div');
-    expect(div.props.style.opacity).toEqual(0.4);
+    expect(div.style.opacity).toEqual('0.4');
   });
 
   it('can be tested with the testing backend', () => {
@@ -41,7 +41,7 @@ describe('Box', () => {
 
     // Check that the opacity is 1
     let div = TestUtils.findRenderedDOMComponentWithTag(root, 'div');
-    expect(div.props.style.opacity).toEqual(1);
+    expect(div.style.opacity).toEqual('1');
 
     // Find the drag source ID and use it to simulate the dragging state
     const box = TestUtils.findRenderedComponentWithType(root, Box);
@@ -49,6 +49,6 @@ describe('Box', () => {
 
     // Verify that the div changed its opacity
     div = TestUtils.findRenderedDOMComponentWithTag(root, 'div');
-    expect(div.props.style.opacity).toEqual(0.4);
+    expect(div.style.opacity).toEqual('0.4');
   });
 });

--- a/examples/01 Dustbin/Single Target/__tests__/Box-test.js
+++ b/examples/01 Dustbin/Single Target/__tests__/Box-test.js
@@ -19,7 +19,7 @@ describe('Box', () => {
                    isDragging={false} />
     );
     let div = TestUtils.findRenderedDOMComponentWithTag(root, 'div');
-	expect(div.style.opacity).toEqual('1');
+    expect(div.style.opacity).toEqual('1');
 
     // Render with another set of props and test
     root = TestUtils.renderIntoDocument(

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
     "animation-frame": "^0.2.4",
@@ -75,10 +75,10 @@
     "mocha": "^2.2.5",
     "null-loader": "^0.1.0",
     "postcss": "^4.0.2",
-    "react": "^0.14.0",
+    "react": "^15.0.0-rc.2",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dnd-test-backend": "^1.0.2",
-    "react-dom": "^0.14.0",
+    "react-dom": "^15.0.0-rc.2",
     "react-hot-loader": "^1.2.3",
     "react-router": "~0.13.2",
     "request": "2.46.0",

--- a/site/IndexPage.js
+++ b/site/IndexPage.js
@@ -4,6 +4,7 @@ import HomePage from './pages/HomePage';
 import APIPage from './pages/APIPage';
 import ExamplePage from './pages/ExamplePage';
 import React, { Component } from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 const APIDocs = {
   OVERVIEW: require('../docs/00 Quick Start/Overview.md'),
@@ -47,7 +48,7 @@ export default class IndexPage extends Component {
 
   static renderToString(props) {
     return IndexPage.getDoctype() +
-           React.renderToString(<IndexPage {...props} />);
+           ReactDOMServer.renderToString(<IndexPage {...props} />);
   }
 
   constructor(props) {


### PR DESCRIPTION
The PR addresses issue #412 by adding support for React 15. Changes done:

- `react` peerDependency changed to allow support for React 15 versions
- Local `react` and `react-dom` versions upgraded to React 15 RC2 (with updates to local website server-side rendering code)
- Fixed broken tests which relied on accessing props of a DOM node. Tests now validate the style attribute value directly instead.

Testing done:
- All examples in the documentation area work correctly as designed
- Tested in Chrome 49
