### PR TITLE
Revert "Upgrade React to stable (15.0.1)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.1"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
     "animation-frame": "^0.2.4",
@@ -75,10 +75,10 @@
     "mocha": "^2.2.5",
     "null-loader": "^0.1.0",
     "postcss": "^4.0.2",
-    "react": "^15.0.1",
+    "react": "^15.0.0-rc.2",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dnd-test-backend": "^1.0.2",
-    "react-dom": "^15.0.1",
+    "react-dom": "^15.0.0-rc.2",
     "react-hot-loader": "^1.2.3",
     "react-router": "~0.13.2",
     "request": "2.46.0",


### PR DESCRIPTION
Reverts gaearon/react-dnd#433.
This is not necessary.
You can find an explanation as to why in https://github.com/reactjs/react-redux/pull/342.