### PR TITLE
Remove unused import from docs

### DIFF
--- a/docs/01 Top Level API/DragLayer.md
+++ b/docs/01 Top Level API/DragLayer.md
@@ -245,7 +245,6 @@ export default DragLayer(collect)(CustomDragLayer);
 import React, { PropTypes } from 'react';
 import ItemTypes from './ItemTypes';
 import BoxDragPreview from './BoxDragPreview';
-import snapToGrid from './snapToGrid';
 import { DragLayer } from 'react-dnd';
 
 const layerStyles = {


### PR DESCRIPTION
While working with the `DragLayer` documentation I found a small unused import in the example code. It's a very trivial change, but to make the docs perfect, I'd suggest taking it out 😁 