### PR TITLE
Adding statics hoisting to HOCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "disposables": "^1.0.1",
     "dnd-core": "^2.0.1",
+    "hoist-non-react-statics": "^1.2.0",
     "invariant": "^2.1.0",
     "lodash": "^4.2.0"
   },

--- a/src/DragDropContext.js
+++ b/src/DragDropContext.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { DragDropManager } from 'dnd-core';
 import invariant from 'invariant';
 import checkDecoratorArguments from './utils/checkDecoratorArguments';
+import hoistStatics from 'hoist-non-react-statics';
 
 export default function DragDropContext(backendOrModule) {
   checkDecoratorArguments('DragDropContext', 'backend', ...arguments);
@@ -30,7 +31,7 @@ export default function DragDropContext(backendOrModule) {
       DecoratedComponent.name ||
       'Component';
 
-    return class DragDropContextContainer extends Component {
+    class DragDropContextContainer extends Component {
       static DecoratedComponent = DecoratedComponent;
 
       static displayName = `DragDropContext(${displayName})`;
@@ -57,6 +58,8 @@ export default function DragDropContext(backendOrModule) {
                               ref='child' />
         );
       }
-    };
+    }
+
+    return hoistStatics(DragDropContextContainer, DecoratedComponent);
   };
 }

--- a/src/DragLayer.js
+++ b/src/DragLayer.js
@@ -4,6 +4,7 @@ import shallowEqualScalar from './utils/shallowEqualScalar';
 import isPlainObject from 'lodash/isPlainObject';
 import invariant from 'invariant';
 import checkDecoratorArguments from './utils/checkDecoratorArguments';
+import hoistStatics from 'hoist-non-react-statics';
 
 export default function DragLayer(collect, options = {}) {
   checkDecoratorArguments('DragLayer', 'collect[, options]', ...arguments);
@@ -31,7 +32,7 @@ export default function DragLayer(collect, options = {}) {
       DecoratedComponent.name ||
       'Component';
 
-    return class DragLayerContainer extends Component {
+    class DragLayerContainer extends Component {
       static DecoratedComponent = DecoratedComponent;
 
       static displayName = `DragLayer(${displayName})`;
@@ -110,6 +111,8 @@ export default function DragLayer(collect, options = {}) {
                               ref='child' />
         );
       }
-    };
+    }
+
+    return hoistStatics(DragLayerContainer, DecoratedComponent);
   };
 }

--- a/src/decorateHandler.js
+++ b/src/decorateHandler.js
@@ -4,6 +4,7 @@ import shallowEqual from './utils/shallowEqual';
 import shallowEqualScalar from './utils/shallowEqualScalar';
 import isPlainObject from 'lodash/isPlainObject';
 import invariant from 'invariant';
+import hoistStatics from 'hoist-non-react-statics';
 
 export default function decorateHandler({
   DecoratedComponent,
@@ -22,7 +23,7 @@ export default function decorateHandler({
     DecoratedComponent.name ||
     'Component';
 
-  return class DragDropContainer extends Component {
+  class DragDropContainer extends Component {
     static DecoratedComponent = DecoratedComponent;
 
     static displayName = `${containerDisplayName}(${displayName})`;
@@ -177,5 +178,7 @@ export default function decorateHandler({
                             ref={this.handleChildRef} />
       );
     }
-  };
+  }
+
+  return hoistStatics(DragDropContainer, DecoratedComponent);
 }


### PR DESCRIPTION
I noticed that statics weren't correctly hoisted for the HOCs. This uses `hoist-non-react-statics` to correctly bring statics up to the HOC.